### PR TITLE
fix facter 3.x compatiblity

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,8 +32,8 @@ class irqbalance (
     $unitfile_active = false
   }
 
-  if $facts['processors']['cores'] < 2 {
-    # systems with 1 physical core can't run irqbalance
+  if $facts['processors']['count'] < 2 {
+    # systems with 1c/1t can't run irqbalance
     # it is part of the internal logic of the binary itself
     systemd::unit_file { $service_name:
       path   => '/usr/lib/systemd/system',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'irqbalance' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge({ 'processors' => { 'cores' => 2 }}) }
+      let(:facts) { os_facts.merge({ 'processors' => { 'count' => 2 }}) }
 
       it { is_expected.to compile }
     end
@@ -13,7 +13,7 @@ describe 'irqbalance' do
     let(:facts) do
       {
         'path' => '/bin:/usr/bin',
-        'processors' => { 'cores' => 2 },
+        'processors' => { 'count' => 2 },
       }
     end
 
@@ -74,7 +74,7 @@ describe 'irqbalance' do
     let(:facts) do
       {
         'path' => '/bin:/usr/bin',
-        'processors' => { 'cores' => 2 },
+        'processors' => { 'count' => 2 },
       }
     end
 
@@ -108,7 +108,7 @@ describe 'irqbalance' do
     let(:facts) do
       {
         'path' => '/bin:/usr/bin',
-        'processors' => { 'cores' => 2 },
+        'processors' => { 'count' => 2 },
       }
     end
 
@@ -129,7 +129,7 @@ describe 'irqbalance' do
     let(:facts) do
       {
         'path' => '/bin:/usr/bin',
-        'processors' => { 'cores' => 1 },
+        'processors' => { 'count' => 1 },
       }
     end
 


### PR DESCRIPTION
Use `facts.processors.count` instead of `facts.processors.cores`, as the
later is facter >= 4 only.

```bash
$ bundle exec facter -v
4.2.9
$ bundle exec facter processors
{
  cores => 4,
  count => 8,
  isa => "x86_64",
  models => [
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz",
    "Intel(R) Xeon(R) CPU E3-1276 v3 @ 3.60GHz"
  ],
  physicalcount => 1,
  speed => "800.00 MHz",
  threads => 2
}
```

```bash
$ facter -v
3.14.21 (commit c7e4edf075b3c2775b3173ab3d5f37dc94644bb1)
$ facter processors
{
  count => 64,
  isa => "x86_64",
  models => [
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor",
    "AMD EPYC 7502P 32-Core Processor"
  ],
  physicalcount => 1,
  speed => "2.50 GHz"
}
```